### PR TITLE
chore: set ID field in /etc/os-release

### DIFF
--- a/files/scripts/00-image-info.sh
+++ b/files/scripts/00-image-info.sh
@@ -19,7 +19,7 @@ FEDORA_MAJOR_VERSION=41
 BASE_IMAGE_NAME="Xfce Atomic $FEDORA_MAJOR_VERSION"
 BASE_IMAGE="quay.io/fedora-ostree-desktops/xfce-atomic"
 
-cat > $IMAGE_INFO <<EOF
+cat >$IMAGE_INFO <<EOF
 {
   "image-name": "$IMAGE_NAME",
   "image-vendor": "$IMAGE_VENDOR",
@@ -34,6 +34,7 @@ EOF
 sed -i "s/^VARIANT_ID=.*/VARIANT_ID=$IMAGE_NAME/" /usr/lib/os-release
 sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${IMAGE_PRETTY_NAME} $VERSION_CODENAME (FROM Fedora ${BASE_IMAGE_NAME^})\"/" /usr/lib/os-release
 sed -i "s/^NAME=.*/NAME=\"$IMAGE_PRETTY_NAME\"/" /usr/lib/os-release
+sed -i "s/^ID=.*/ID=\"$IMAGE_NAME\"/" /usr/lib/os-release
 sed -i "s|^HOME_URL=.*|HOME_URL=\"$HOME_URL\"|" /usr/lib/os-release
 sed -i "s|^DOCUMENTATION_URL=.*|DOCUMENTATION_URL=\"$DOCUMENTATION_URL\"|" /usr/lib/os-release
 sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"$SUPPORT_URL\"|" /usr/lib/os-release


### PR DESCRIPTION
![Screenshot_2025-03-30_18-33-17](https://github.com/user-attachments/assets/9a6cade4-785b-4574-b269-86b75b530adb)
This should set the default hostname to be blue95 instead of vauxite.