### PR TITLE
design: reduce size of tasklist icons for Xfce 4.20

### DIFF
--- a/files/scripts/21-de-tweaks.sh
+++ b/files/scripts/21-de-tweaks.sh
@@ -5,6 +5,9 @@ set -oeux pipefail
 # Logo for the "About Xfce" app
 cp /usr/share/winblues/icons/blue95.png /usr/share/icons/Chicago95/apps/scalable/fedora-logo-icon.png
 
+# Make the taskbar icons smaller
+echo ".tasklist button box image { -gtk-icon-transform: scale(0.8); }" >>/usr/share/themes/Chicago95/gtk-3.0/apps/xfce-panel-hacks.css
+
 # TODO: see if we can upstream any of this
 
 # Battery panel icon tweaks (stay on full icon from 100% to 90%)

--- a/files/scripts/21-de-tweaks.sh
+++ b/files/scripts/21-de-tweaks.sh
@@ -5,6 +5,7 @@ set -oeux pipefail
 # Logo for the "About Xfce" app
 cp /usr/share/winblues/icons/blue95.png /usr/share/icons/Chicago95/apps/scalable/fedora-logo-icon.png
 
+# TODO: remove when https://github.com/grassmunk/Chicago95/pull/383 is merged
 # Make the taskbar icons smaller
 echo ".tasklist button box image { -gtk-icon-transform: scale(0.8); }" >>/usr/share/themes/Chicago95/gtk-3.0/apps/xfce-panel-hacks.css
 


### PR DESCRIPTION
Tasklist icon sizes have been reworked in Xfce 4.20 and the default size is larger than it was in Xfce 4.18. I believe 0.8 scaling is the closest to the look in Xfce 4.18.

Current tasklist icon size with no scaling:
![tasklist-1 0](https://github.com/user-attachments/assets/e0d9bf8a-a1a4-4044-9678-c32c88669440)

Scaling factor 0.9:
![tasklist-0 9](https://github.com/user-attachments/assets/f76cbb12-de18-40d7-bf85-d24c5f5fc459)

Scaling factor 0.8:
![tasklist-0 8](https://github.com/user-attachments/assets/339ca652-ad49-40f7-8991-38fa70ff7d4b)

Scaling factor 0.75:
![tasklist-0 75](https://github.com/user-attachments/assets/101cfdc9-cbf1-47b2-b5a5-2d81caa246ba)

