### PR TITLE
Add 'script' to the recipe dependencies

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -44,6 +44,7 @@ modules:
       - qemu
       - qt5ct
       - qt5-qtstyleplugins
+      - script
       - sox
       - strace
       - virt-manager


### PR DESCRIPTION
The installer doesn't start without `script`.

Tested 2025-11-17 with the latest live ISO.

