### PR TITLE
Switch Firefox from Flatpak to RPM with win95 retro theme

### DIFF
--- a/files/scripts/25-firefox-theme.js
+++ b/files/scripts/25-firefox-theme.js
@@ -1,0 +1,47 @@
+// skip 1st line
+try {
+  const ds = Cc['@mozilla.org/file/directory_service;1'].getService(Ci.nsIProperties);
+  const profileDir = ds.get('ProfD', Ci.nsIFile);
+
+  const chromeDir = profileDir.clone();
+  chromeDir.append('chrome');
+  const utilsDir = chromeDir.clone();
+  utilsDir.append('utils');
+
+  // Blue95: bootstrap win95 theme on first launch by copying from the
+  // system-provided template at browser/defaults/profile/chrome/.
+  // fx-autoconfig alone can't do this because boot.sys.mjs only runs
+  // after chrome/utils/chrome.manifest already exists.
+  if (!utilsDir.exists()) {
+    const template = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsIFile);
+    template.initWithPath('/usr/lib64/firefox/browser/defaults/profile/chrome');
+    if (template.exists()) {
+      try {
+        if (!chromeDir.exists()) {
+          template.copyTo(profileDir, 'chrome');
+        } else {
+          // chrome/ exists (e.g. user has userChrome.css) — merge in our files
+          const entries = template.directoryEntries;
+          while (entries.hasMoreElements()) {
+            const entry = entries.getNext().QueryInterface(Ci.nsIFile);
+            const dest = chromeDir.clone();
+            dest.append(entry.leafName);
+            if (!dest.exists()) {
+              entry.copyTo(chromeDir, entry.leafName);
+            }
+          }
+        }
+      } catch(copyErr) {}
+    }
+  }
+
+  // fx-autoconfig: register chrome manifest and load the userscript boot loader
+  const cmanifest = utilsDir.clone();
+  cmanifest.append('chrome.manifest');
+
+  if (cmanifest.exists()) {
+    Components.manager.QueryInterface(Ci.nsIComponentRegistrar).autoRegister(cmanifest);
+    ChromeUtils.importESModule('chrome://userchromejs/content/boot.sys.mjs');
+  }
+
+} catch(ex) {};

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -45,26 +45,29 @@ cp "$FXAC_DIR/program/defaults/pref/config-prefs.js" \
    /usr/lib64/firefox/defaults/pref/config-prefs.js
 
 # ---------------------------------------------------------------------------
-# Stage theme files to a well-known path — chezmoi applies them per-profile
-# on first login
+# Install theme files into Firefox's default profile template.
+# Firefox copies this directory into every new profile on first launch,
+# so the theme is applied automatically without any per-user setup.
+# The chezmoi script handles the upgrade case (existing profiles).
 # ---------------------------------------------------------------------------
-THEME_DEST=/usr/share/winblues/firefox-theme
-mkdir -p "$THEME_DEST/CSS" "$THEME_DEST/JS/userscript" "$THEME_DEST/utils"
+PROFILE_TEMPLATE=/usr/lib64/firefox/browser/defaults/profile
+CHROME_DEST="$PROFILE_TEMPLATE/chrome"
+mkdir -p "$CHROME_DEST/CSS" "$CHROME_DEST/JS/userscript" "$CHROME_DEST/utils"
 
 # Compiled CSS
-cp "$WIN95_DIR/dist/firefox_agent.css"  "$THEME_DEST/CSS/win95_agent.uc.css"
-cp "$WIN95_DIR/dist/firefox_author.css" "$THEME_DEST/CSS/win95_author.uc.css"
-cp "$WIN95_DIR/dist/firefox_global.css" "$THEME_DEST/CSS/firefox_global.uc.css"
+cp "$WIN95_DIR/dist/firefox_agent.css"  "$CHROME_DEST/CSS/win95_agent.uc.css"
+cp "$WIN95_DIR/dist/firefox_author.css" "$CHROME_DEST/CSS/win95_author.uc.css"
+cp "$WIN95_DIR/dist/firefox_global.css" "$CHROME_DEST/CSS/firefox_global.uc.css"
 # userChrome.css is read by Firefox directly; author sheet is identical
-cp "$WIN95_DIR/dist/firefox_author.css" "$THEME_DEST/userChrome.css"
+cp "$WIN95_DIR/dist/firefox_author.css" "$CHROME_DEST/userChrome.css"
 
 # JS userscript and its imports
-cp "$WIN95_DIR/src/firefox/win95_main.uc.mjs"          "$THEME_DEST/JS/"
-cp "$WIN95_DIR/src/firefox/userscript/prefs.js"        "$THEME_DEST/JS/userscript/"
-cp "$WIN95_DIR/src/firefox/userscript/resizer.js"      "$THEME_DEST/JS/userscript/"
+cp "$WIN95_DIR/src/firefox/win95_main.uc.mjs"          "$CHROME_DEST/JS/"
+cp "$WIN95_DIR/src/firefox/userscript/prefs.js"        "$CHROME_DEST/JS/userscript/"
+cp "$WIN95_DIR/src/firefox/userscript/resizer.js"      "$CHROME_DEST/JS/userscript/"
 
 # fx-autoconfig profile utils (the actual script loader)
-cp "$FXAC_DIR/profile/chrome/utils/"* "$THEME_DEST/utils/"
+cp "$FXAC_DIR/profile/chrome/utils/"* "$CHROME_DEST/utils/"
 
 # ---------------------------------------------------------------------------
 # System-wide Firefox preferences

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -39,7 +39,55 @@ FXAC_DIR="fx-autoconfig-${FXAC_SHA}"
 # Install fx-autoconfig program files → overlay onto Firefox install
 # These make Firefox load userscripts/CSS from any profile's chrome/ dir
 # ---------------------------------------------------------------------------
-cp "$FXAC_DIR/program/config.js" /usr/lib64/firefox/config.js
+cat > /usr/lib64/firefox/config.js << 'CONFIGEOF'
+// skip 1st line
+try {
+  const ds = Cc['@mozilla.org/file/directory_service;1'].getService(Ci.nsIProperties);
+  const profileDir = ds.get('ProfD', Ci.nsIFile);
+
+  const chromeDir = profileDir.clone();
+  chromeDir.append('chrome');
+  const utilsDir = chromeDir.clone();
+  utilsDir.append('utils');
+
+  // Blue95: bootstrap win95 theme on first launch by copying from the
+  // system-provided template at browser/defaults/profile/chrome/.
+  // fx-autoconfig alone can't do this because boot.sys.mjs only runs
+  // after chrome/utils/chrome.manifest already exists.
+  if (!utilsDir.exists()) {
+    const template = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsIFile);
+    template.initWithPath('/usr/lib64/firefox/browser/defaults/profile/chrome');
+    if (template.exists()) {
+      try {
+        if (!chromeDir.exists()) {
+          template.copyTo(profileDir, 'chrome');
+        } else {
+          // chrome/ exists (e.g. user has userChrome.css) — merge in our files
+          const entries = template.directoryEntries;
+          while (entries.hasMoreElements()) {
+            const entry = entries.getNext().QueryInterface(Ci.nsIFile);
+            const dest = chromeDir.clone();
+            dest.append(entry.leafName);
+            if (!dest.exists()) {
+              entry.copyTo(chromeDir, entry.leafName);
+            }
+          }
+        }
+      } catch(copyErr) {}
+    }
+  }
+
+  // fx-autoconfig: register chrome manifest and load the userscript boot loader
+  const cmanifest = utilsDir.clone();
+  cmanifest.append('chrome.manifest');
+
+  if (cmanifest.exists()) {
+    Components.manager.QueryInterface(Ci.nsIComponentRegistrar).autoRegister(cmanifest);
+    ChromeUtils.importESModule('chrome://userchromejs/content/boot.sys.mjs');
+  }
+
+} catch(ex) {};
+CONFIGEOF
 mkdir -p /usr/lib64/firefox/defaults/pref
 cp "$FXAC_DIR/program/defaults/pref/config-prefs.js" \
    /usr/lib64/firefox/defaults/pref/config-prefs.js

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -10,6 +10,7 @@ set -xueo pipefail
 WIN95_SHA=d1d459c78939370beb524f845cccd46094ea3704   # v2.3.0
 FXAC_SHA=54f88294ea70f1d13ded482351da068d5f21c004
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TMPDIR=$(mktemp -d)
 cd "$TMPDIR"
 
@@ -39,55 +40,7 @@ FXAC_DIR="fx-autoconfig-${FXAC_SHA}"
 # Install fx-autoconfig program files → overlay onto Firefox install
 # These make Firefox load userscripts/CSS from any profile's chrome/ dir
 # ---------------------------------------------------------------------------
-cat > /usr/lib64/firefox/config.js << 'CONFIGEOF'
-// skip 1st line
-try {
-  const ds = Cc['@mozilla.org/file/directory_service;1'].getService(Ci.nsIProperties);
-  const profileDir = ds.get('ProfD', Ci.nsIFile);
-
-  const chromeDir = profileDir.clone();
-  chromeDir.append('chrome');
-  const utilsDir = chromeDir.clone();
-  utilsDir.append('utils');
-
-  // Blue95: bootstrap win95 theme on first launch by copying from the
-  // system-provided template at browser/defaults/profile/chrome/.
-  // fx-autoconfig alone can't do this because boot.sys.mjs only runs
-  // after chrome/utils/chrome.manifest already exists.
-  if (!utilsDir.exists()) {
-    const template = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsIFile);
-    template.initWithPath('/usr/lib64/firefox/browser/defaults/profile/chrome');
-    if (template.exists()) {
-      try {
-        if (!chromeDir.exists()) {
-          template.copyTo(profileDir, 'chrome');
-        } else {
-          // chrome/ exists (e.g. user has userChrome.css) — merge in our files
-          const entries = template.directoryEntries;
-          while (entries.hasMoreElements()) {
-            const entry = entries.getNext().QueryInterface(Ci.nsIFile);
-            const dest = chromeDir.clone();
-            dest.append(entry.leafName);
-            if (!dest.exists()) {
-              entry.copyTo(chromeDir, entry.leafName);
-            }
-          }
-        }
-      } catch(copyErr) {}
-    }
-  }
-
-  // fx-autoconfig: register chrome manifest and load the userscript boot loader
-  const cmanifest = utilsDir.clone();
-  cmanifest.append('chrome.manifest');
-
-  if (cmanifest.exists()) {
-    Components.manager.QueryInterface(Ci.nsIComponentRegistrar).autoRegister(cmanifest);
-    ChromeUtils.importESModule('chrome://userchromejs/content/boot.sys.mjs');
-  }
-
-} catch(ex) {};
-CONFIGEOF
+cp "$SCRIPT_DIR/25-firefox-theme.js" /usr/lib64/firefox/config.js
 mkdir -p /usr/lib64/firefox/defaults/pref
 cp "$FXAC_DIR/program/defaults/pref/config-prefs.js" \
    /usr/lib64/firefox/defaults/pref/config-prefs.js

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -22,7 +22,7 @@ wget -q "https://github.com/ricewind012/win95-themes/archive/${WIN95_SHA}.zip" -
 unzip -q win95.zip
 WIN95_DIR="win95-themes-${WIN95_SHA}"
 cd "$WIN95_DIR"
-npm ci --prefer-offline
+npm install --prefer-offline
 npm run build firefox agent
 npm run build firefox author
 npm run build firefox global

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -65,6 +65,13 @@ cp "$WIN95_DIR/src/shared/colors/"*.css "$CHROME_DEST/CSS/colors/"
 # Do NOT also place firefox_author.css in CSS/ — fx-autoconfig would load it via a chrome://
 # URL where the same relative import resolves to a nonexistent double-nested path.
 cp "$WIN95_DIR/dist/firefox_author.css" "$CHROME_DEST/userChrome.css"
+# Blue95: bump UI font size from Win95's original 11px to 14px for readability
+# on modern displays. This overrides --text-ui-size via cascade (later :root wins).
+cat >> "$CHROME_DEST/userChrome.css" << 'CSSEOF'
+
+/* Blue95: increase UI font size for readability on modern displays */
+:root { --text-ui-size: 14px; }
+CSSEOF
 
 # JS userscript and its imports
 cp "$WIN95_DIR/src/firefox/win95_main.uc.mjs"          "$CHROME_DEST/JS/"

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -xueo pipefail
+
+# win95-themes: Windows 95 browser chrome for Firefox
+# fx-autoconfig: userscript/CSS loader required by win95-themes
+#
+# Pinned SHAs — bump these together when Firefox breaks the theme.
+# win95-themes tracks Nightly so breakage is usually caught and fixed quickly.
+WIN95_SHA=d1d459c78939370beb524f845cccd46094ea3704   # v2.3.0
+FXAC_SHA=54f88294ea70f1d13ded482351da068d5f21c004
+
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+
+# ---------------------------------------------------------------------------
+# Build win95-themes CSS
+# ---------------------------------------------------------------------------
+dnf install -y nodejs
+
+wget -q "https://github.com/ricewind012/win95-themes/archive/${WIN95_SHA}.zip" -O win95.zip
+unzip -q win95.zip
+WIN95_DIR="win95-themes-${WIN95_SHA}"
+cd "$WIN95_DIR"
+npm ci --prefer-offline
+npm run build firefox agent
+npm run build firefox author
+npm run build firefox global
+cd "$TMPDIR"
+
+# ---------------------------------------------------------------------------
+# Fetch fx-autoconfig
+# ---------------------------------------------------------------------------
+wget -q "https://github.com/MrOtherGuy/fx-autoconfig/archive/${FXAC_SHA}.zip" -O fxac.zip
+unzip -q fxac.zip
+FXAC_DIR="fx-autoconfig-${FXAC_SHA}"
+
+# ---------------------------------------------------------------------------
+# Install fx-autoconfig program files → overlay onto Firefox install
+# These make Firefox load userscripts/CSS from any profile's chrome/ dir
+# ---------------------------------------------------------------------------
+cp "$FXAC_DIR/program/config.js" /usr/lib64/firefox/config.js
+mkdir -p /usr/lib64/firefox/defaults/pref
+cp "$FXAC_DIR/program/defaults/pref/config-prefs.js" \
+   /usr/lib64/firefox/defaults/pref/config-prefs.js
+
+# ---------------------------------------------------------------------------
+# Stage theme files to a well-known path — chezmoi applies them per-profile
+# on first login
+# ---------------------------------------------------------------------------
+THEME_DEST=/usr/share/winblues/firefox-theme
+mkdir -p "$THEME_DEST/CSS" "$THEME_DEST/JS/userscript" "$THEME_DEST/utils"
+
+# Compiled CSS
+cp "$WIN95_DIR/dist/firefox_agent.css"  "$THEME_DEST/CSS/win95_agent.uc.css"
+cp "$WIN95_DIR/dist/firefox_author.css" "$THEME_DEST/CSS/win95_author.uc.css"
+cp "$WIN95_DIR/dist/firefox_global.css" "$THEME_DEST/CSS/firefox_global.uc.css"
+# userChrome.css is read by Firefox directly; author sheet is identical
+cp "$WIN95_DIR/dist/firefox_author.css" "$THEME_DEST/userChrome.css"
+
+# JS userscript and its imports
+cp "$WIN95_DIR/src/firefox/win95_main.uc.mjs"          "$THEME_DEST/JS/"
+cp "$WIN95_DIR/src/firefox/userscript/prefs.js"        "$THEME_DEST/JS/userscript/"
+cp "$WIN95_DIR/src/firefox/userscript/resizer.js"      "$THEME_DEST/JS/userscript/"
+
+# fx-autoconfig profile utils (the actual script loader)
+cp "$FXAC_DIR/profile/chrome/utils/"* "$THEME_DEST/utils/"
+
+# ---------------------------------------------------------------------------
+# System-wide Firefox preferences
+# Applied to all profiles; user.js written by chezmoi can still override.
+# ---------------------------------------------------------------------------
+cat > /usr/lib64/firefox/browser/defaults/preferences/blue95-firefox.js << 'EOF'
+// Blue95: enable userChrome.css and userscripts
+pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
+
+// Win95 theme requirements
+pref("ui.prefersReducedMotion", 1);
+pref("widget.gtk.overlay-scrollbars.enabled", false);
+pref("widget.non-native-theme.scrollbar.size.override", 16);
+pref("widget.non-native-theme.scrollbar.style", 4);
+pref("browser.tabs.tabMinWidth", 120);
+pref("browser.theme.dark-private-windows", false);
+pref("browser.urlbar.trimURLs", false);
+pref("identity.fxaccounts.enabled", false);
+
+// Required for sidebar theming; may be removed by Mozilla eventually
+pref("sidebar.revamp", true);
+EOF
+
+# ---------------------------------------------------------------------------
+# Clean up — nodejs should not be in the final image
+# ---------------------------------------------------------------------------
+dnf remove -y nodejs
+dnf autoremove -y
+rm -rf "$TMPDIR"

--- a/files/scripts/25-firefox-theme.sh
+++ b/files/scripts/25-firefox-theme.sh
@@ -53,13 +53,17 @@ cp "$FXAC_DIR/program/defaults/pref/config-prefs.js" \
 # ---------------------------------------------------------------------------
 PROFILE_TEMPLATE=/usr/lib64/firefox/browser/defaults/profile
 CHROME_DEST="$PROFILE_TEMPLATE/chrome"
-mkdir -p "$CHROME_DEST/CSS" "$CHROME_DEST/JS/userscript" "$CHROME_DEST/utils"
+mkdir -p "$CHROME_DEST/CSS/colors" "$CHROME_DEST/JS/userscript" "$CHROME_DEST/utils"
 
 # Compiled CSS
 cp "$WIN95_DIR/dist/firefox_agent.css"  "$CHROME_DEST/CSS/win95_agent.uc.css"
-cp "$WIN95_DIR/dist/firefox_author.css" "$CHROME_DEST/CSS/win95_author.uc.css"
 cp "$WIN95_DIR/dist/firefox_global.css" "$CHROME_DEST/CSS/firefox_global.uc.css"
-# userChrome.css is read by Firefox directly; author sheet is identical
+# Color theme files (imported by firefox_global.uc.css as relative "colors/..." paths)
+cp "$WIN95_DIR/src/shared/colors/"*.css "$CHROME_DEST/CSS/colors/"
+# userChrome.css: loaded by Firefox natively (not via fx-autoconfig) from the chrome root.
+# Its relative @import "./CSS/firefox_global.uc.css" resolves correctly from here.
+# Do NOT also place firefox_author.css in CSS/ — fx-autoconfig would load it via a chrome://
+# URL where the same relative import resolves to a nonexistent double-nested path.
 cp "$WIN95_DIR/dist/firefox_author.css" "$CHROME_DEST/userChrome.css"
 
 # JS userscript and its imports
@@ -90,6 +94,15 @@ pref("identity.fxaccounts.enabled", false);
 
 // Required for sidebar theming; may be removed by Mozilla eventually
 pref("sidebar.revamp", true);
+
+// Win95 color theme (controls which colors/ CSS is loaded)
+pref("win95.colors", "win2000");
+
+// Let xfwm4/Chicago95 draw the Win95-style WM title bar instead of Firefox CSD
+pref("browser.tabs.inTitlebar", 0);
+
+// Show text labels on toolbar buttons (classic Win95 IE style)
+pref("win95.navbar-button-labels", true);
 EOF
 
 # ---------------------------------------------------------------------------

--- a/files/system/etc/skel/.config/xfce4/panel/launcher-14/17424724602.desktop
+++ b/files/system/etc/skel/.config/xfce4/panel/launcher-14/17424724602.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=/usr/bin/palemoon
+Exec=/usr/bin/firefox %u
 Terminal=false
 X-MultipleArgs=false
 Icon=firefox
@@ -9,6 +9,6 @@ DBusActivatable=false
 Categories=GTK;Network;WebBrowser;
 StartupNotify=true
 Name=Web Browser
-X-XFCE-Source=file:///usr/share/applications/palemoon.desktop
+X-XFCE-Source=file:///usr/share/applications/firefox.desktop
 Comment=Browse the web
 Path=

--- a/files/system/etc/ublue-os/system-flatpaks.list
+++ b/files/system/etc/ublue-os/system-flatpaks.list
@@ -2,4 +2,3 @@ org.gtk.Gtk3theme.Chicago95
 com.tomjwatson.Emote
 org.libreoffice.LibreOffice
 org.geany.Geany
-org.mozilla.firefox

--- a/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
+++ b/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
@@ -4,29 +4,40 @@ set -euo pipefail
 
 [[ -n "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE-}" ]] && source "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE}"
 
-# New profiles automatically get the theme via Firefox's default profile
-# template at /usr/lib64/firefox/browser/defaults/profile/chrome/.
-#
-# This script handles the upgrade case only: existing profiles that were
-# created before the theme was introduced need the chrome/ files copied in.
+# New profiles get the win95 theme automatically on first Firefox launch via
+# config.js bootstrapping. This script handles the upgrade case: existing
+# profiles that predate the theme and won't trigger the bootstrap copy because
+# they already have a chrome/ directory with a chrome.manifest.
 
 CHROME_SRC=/usr/lib64/firefox/browser/defaults/profile/chrome
-PROFILES_INI="$HOME/.mozilla/firefox/profiles.ini"
 
-if [[ ! -f "$PROFILES_INI" ]]; then
-  # No native Firefox profile yet — new profile will get theme on first launch
+# Firefox uses the XDG path on modern Fedora, legacy path on older systems
+PROFILES_DIR=""
+for candidate in \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox" \
+    "$HOME/.mozilla/firefox"; do
+  if [[ -f "$candidate/profiles.ini" ]]; then
+    PROFILES_DIR="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$PROFILES_DIR" ]]; then
+  # No profiles yet — first launch will trigger the config.js bootstrap
   exit 0
 fi
 
-# Find all profiles and copy theme files into any that are missing chrome/
 while IFS='=' read -r key value; do
-  if [[ "$key" == "Path" ]]; then
-    PROFILE_DIR="$HOME/.mozilla/firefox/${value// /}"
-    CHROME_DEST="$PROFILE_DIR/chrome"
-    if [[ -d "$PROFILE_DIR" && ! -d "$CHROME_DEST/utils" ]]; then
-      echo "Applying win95 Firefox theme to profile: $value"
-      mkdir -p "$CHROME_DEST"
-      cp -r "$CHROME_SRC/." "$CHROME_DEST/"
-    fi
+  [[ "$key" != "Path" ]] && continue
+  PROFILE_DIR="$PROFILES_DIR/${value// /}"
+  [[ ! -d "$PROFILE_DIR" ]] && continue
+
+  CHROME_DEST="$PROFILE_DIR/chrome"
+  UTILS_DEST="$CHROME_DEST/utils"
+
+  if [[ ! -d "$UTILS_DEST" ]]; then
+    echo "Applying win95 Firefox theme to profile: $value"
+    mkdir -p "$CHROME_DEST"
+    cp -r "$CHROME_SRC/." "$CHROME_DEST/"
   fi
-done < "$PROFILES_INI"
+done < "$PROFILES_DIR/profiles.ini"

--- a/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
+++ b/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+[[ -n "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE-}" ]] && source "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE}"
+
+THEME_SRC=/usr/share/winblues/firefox-theme
+PROFILES_INI="$HOME/.mozilla/firefox/profiles.ini"
+
+# Nothing to do if Firefox has never been launched yet (no profiles.ini).
+# The script is re-run by chezmoi on each login so it will wire up the theme
+# the first time Firefox creates a profile.
+if [[ ! -f "$PROFILES_INI" ]]; then
+  echo "No Firefox profiles.ini found, skipping theme setup"
+  exit 0
+fi
+
+# Find the path of the default profile.
+# profiles.ini uses INI sections like [Profile0]; the default has Default=1.
+PROFILE_REL=$(python3 - <<'EOF'
+import configparser, sys
+ini = configparser.ConfigParser()
+ini.read(sys.argv[1] if len(sys.argv) > 1 else "")
+for s in ini.sections():
+    if ini.get(s, "Default", fallback="0") == "1":
+        print(ini.get(s, "Path", fallback=""))
+        sys.exit(0)
+EOF
+"$PROFILES_INI")
+
+if [[ -z "$PROFILE_REL" ]]; then
+  echo "Could not determine default Firefox profile, skipping theme setup"
+  exit 0
+fi
+
+PROFILE_DIR="$HOME/.mozilla/firefox/$PROFILE_REL"
+CHROME_DIR="$PROFILE_DIR/chrome"
+
+echo "Setting up win95 Firefox theme in: $PROFILE_DIR"
+
+mkdir -p "$CHROME_DIR/CSS" "$CHROME_DIR/JS" "$CHROME_DIR/utils"
+
+# fx-autoconfig loader (makes Firefox pick up .uc.css / .uc.mjs files)
+cp -f "$THEME_SRC/utils/"* "$CHROME_DIR/utils/"
+
+# Theme CSS and JS
+cp -f "$THEME_SRC/CSS/"* "$CHROME_DIR/CSS/"
+cp -rf "$THEME_SRC/JS/"* "$CHROME_DIR/JS/"
+cp -f "$THEME_SRC/userChrome.css" "$CHROME_DIR/userChrome.css"

--- a/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
+++ b/files/system/usr/share/winblues/chezmoi/.chezmoiscripts/run_after_04-firefox-theme.sh
@@ -4,46 +4,29 @@ set -euo pipefail
 
 [[ -n "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE-}" ]] && source "${WINBLUES_CHEZMOI_ORIGINAL_ENV_FILE}"
 
-THEME_SRC=/usr/share/winblues/firefox-theme
+# New profiles automatically get the theme via Firefox's default profile
+# template at /usr/lib64/firefox/browser/defaults/profile/chrome/.
+#
+# This script handles the upgrade case only: existing profiles that were
+# created before the theme was introduced need the chrome/ files copied in.
+
+CHROME_SRC=/usr/lib64/firefox/browser/defaults/profile/chrome
 PROFILES_INI="$HOME/.mozilla/firefox/profiles.ini"
 
-# Nothing to do if Firefox has never been launched yet (no profiles.ini).
-# The script is re-run by chezmoi on each login so it will wire up the theme
-# the first time Firefox creates a profile.
 if [[ ! -f "$PROFILES_INI" ]]; then
-  echo "No Firefox profiles.ini found, skipping theme setup"
+  # No native Firefox profile yet — new profile will get theme on first launch
   exit 0
 fi
 
-# Find the path of the default profile.
-# profiles.ini uses INI sections like [Profile0]; the default has Default=1.
-PROFILE_REL=$(python3 - <<'EOF'
-import configparser, sys
-ini = configparser.ConfigParser()
-ini.read(sys.argv[1] if len(sys.argv) > 1 else "")
-for s in ini.sections():
-    if ini.get(s, "Default", fallback="0") == "1":
-        print(ini.get(s, "Path", fallback=""))
-        sys.exit(0)
-EOF
-"$PROFILES_INI")
-
-if [[ -z "$PROFILE_REL" ]]; then
-  echo "Could not determine default Firefox profile, skipping theme setup"
-  exit 0
-fi
-
-PROFILE_DIR="$HOME/.mozilla/firefox/$PROFILE_REL"
-CHROME_DIR="$PROFILE_DIR/chrome"
-
-echo "Setting up win95 Firefox theme in: $PROFILE_DIR"
-
-mkdir -p "$CHROME_DIR/CSS" "$CHROME_DIR/JS" "$CHROME_DIR/utils"
-
-# fx-autoconfig loader (makes Firefox pick up .uc.css / .uc.mjs files)
-cp -f "$THEME_SRC/utils/"* "$CHROME_DIR/utils/"
-
-# Theme CSS and JS
-cp -f "$THEME_SRC/CSS/"* "$CHROME_DIR/CSS/"
-cp -rf "$THEME_SRC/JS/"* "$CHROME_DIR/JS/"
-cp -f "$THEME_SRC/userChrome.css" "$CHROME_DIR/userChrome.css"
+# Find all profiles and copy theme files into any that are missing chrome/
+while IFS='=' read -r key value; do
+  if [[ "$key" == "Path" ]]; then
+    PROFILE_DIR="$HOME/.mozilla/firefox/${value// /}"
+    CHROME_DEST="$PROFILE_DIR/chrome"
+    if [[ -d "$PROFILE_DIR" && ! -d "$CHROME_DEST/utils" ]]; then
+      echo "Applying win95 Firefox theme to profile: $value"
+      mkdir -p "$CHROME_DEST"
+      cp -r "$CHROME_SRC/." "$CHROME_DEST/"
+    fi
+  fi
+done < "$PROFILES_INI"

--- a/files/system/usr/share/winblues/chezmoi/dot_local/share/xfce-panel-profile/launcher-14/17424724602.desktop
+++ b/files/system/usr/share/winblues/chezmoi/dot_local/share/xfce-panel-profile/launcher-14/17424724602.desktop
@@ -1,14 +1,14 @@
 [Desktop Entry]
 Type=Application
-Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=firefox --file-forwarding org.mozilla.firefox @@u %u @@
+Exec=/usr/bin/firefox %u
 Terminal=false
 X-MultipleArgs=false
 Icon=firefox
 StartupWMClass=firefox
 DBusActivatable=false
-Categories=GNOME;GTK;Network;WebBrowser;
+Categories=GTK;Network;WebBrowser;
 StartupNotify=true
 Name=Web Browser
-X-XFCE-Source=file:///var/lib/flatpak/exports/share/applications/org.mozilla.firefox.desktop
+X-XFCE-Source=file:///usr/share/applications/firefox.desktop
 Comment=Browse the web
 Path=

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -70,6 +70,7 @@ modules:
       # Raw RPMs
       - https://github.com/felixrieseberg/clippy/releases/download/v0.4.3/Clippy-0.4.3-1.x86_64.rpm
       - https://github.com/1j01/jspaint/releases/download/v1.0.0-beta.1/jspaint-1.0.0-Linux-x64.rpm
+      - firefox
 
 
   - type: default-flatpaks
@@ -82,7 +83,6 @@ modules:
           - com.tomjwatson.Emote
           - org.geany.Geany
           - org.libreoffice.LibreOffice
-          - org.mozilla.firefox
 
   - type: files
     files:


### PR DESCRIPTION
## Summary

- Replaces \`org.mozilla.firefox\` Flatpak with the \`firefox\` RPM, eliminating all Flatpak sandbox issues (drag-and-drop, filesystem access, native messaging)
- Adds \`25-firefox-theme.sh\`: installs nodejs at build time, builds [win95-themes](https://github.com/ricewind012/win95-themes) CSS, installs [fx-autoconfig](https://github.com/MrOtherGuy/fx-autoconfig) to \`/usr/lib64/firefox/\`, and stages theme files into Firefox's default profile template (\`/usr/lib64/firefox/browser/defaults/profile/chrome/\`); nodejs is removed after the build
- Adds \`run_after_04-firefox-theme.sh\`: chezmoi script that copies the theme into any existing profiles on upgrade (new profiles are handled automatically by \`config.js\` bootstrap on first launch)
- Updates the panel launcher from Pale Moon → \`/usr/bin/firefox\`
- Installs \`browser/defaults/preferences/blue95-firefox.js\` with all required system-wide Firefox prefs

## System prefs set

| Pref | Value | Purpose |
|---|---|---|
| \`toolkit.legacyUserProfileCustomizations.stylesheets\` | \`true\` | Enable userChrome.css |
| \`win95.colors\` | \`win2000\` | Load Win2000 color palette (required — without this no color variables are defined) |
| \`browser.tabs.inTitlebar\` | \`0\` | Let xfwm4/Chicago95 draw the Win95-style WM title bar |
| \`win95.navbar-button-labels\` | \`true\` | IE-style text labels on toolbar buttons |
| \`sidebar.revamp\` | \`true\` | Required for sidebar theming |
| \`widget.gtk.overlay-scrollbars.enabled\` | \`false\` | Win95-style scrollbars |
| \`widget.non-native-theme.scrollbar.size.override\` | \`16\` | Correct scrollbar size |
| \`widget.non-native-theme.scrollbar.style\` | \`4\` | Win95 scrollbar style |

## Pinned versions

| Component | SHA |
|---|---|
| win95-themes | \`d1d459c78939\` (v2.3.0) |
| fx-autoconfig | \`54f88294ea70\` |

## Testing

To test without waiting for CI, rebase to the PR image tag once the CI build completes:
\`\`\`
rpm-ostree rebase ostree-image-signed:docker://ghcr.io/winblues/blue95:pr-94-43
\`\`\`

Or test the theme wiring live on an unlocked system by running \`25-firefox-theme.sh\` directly and then triggering the chezmoi script.

## Maintenance note

The win95-themes CSS targets Firefox internal element IDs which can break on Firefox updates. Firefox is **not pinned** — it updates freely via the base image. When the theme breaks after a Firefox update, bump \`WIN95_SHA\` in \`25-firefox-theme.sh\` to the latest win95-themes release and rebuild.