### PR TITLE
fix: volume icon notifications

### DIFF
--- a/files/scripts/20-chicago95-notifyd.diff
+++ b/files/scripts/20-chicago95-notifyd.diff
@@ -1,0 +1,12 @@
+diff --git a/Theme/Chicago95/xfce-notify-4.0/gtk.css b/Theme/Chicago95/xfce-notify-4.0/gtk.css
+index de79800..308e848 100755
+--- a/Theme/Chicago95/xfce-notify-4.0/gtk.css
++++ b/Theme/Chicago95/xfce-notify-4.0/gtk.css
+@@ -14,3 +14,7 @@
+   padding: 2px;
+   
+ }
++
++#XfceNotifyWindow image {
++  -gtk-icon-style: regular;
++}

--- a/files/scripts/20-chicago95.sh
+++ b/files/scripts/20-chicago95.sh
@@ -4,6 +4,7 @@ set -xueo pipefail
 
 diff=$(realpath 20-chicago95.diff)
 xfwm4_diff=$(realpath 20-chicago95-xfwm4.diff)
+notifyd_diff=$(realpath 20-chicago95-notifyd.diff)
 
 # Fetch
 TMPDIR=$(mktemp -d)
@@ -20,6 +21,9 @@ patch -p1 <$diff
 
 # Resize xfwm4 title bar to 28 px with square buttons
 patch -p1 <$xfwm4_diff
+
+# Fix volume notification icon rendering (force regular/color icons over symbolic)
+patch -p1 <$notifyd_diff
 
 # Themes
 cp -r Theme/Chicago95 /usr/share/themes

--- a/files/system/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
+++ b/files/system/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
@@ -9,4 +9,5 @@
   </property>
   <property name="theme" type="string" value="Chicago95"/>
   <property name="notify-location" type="string" value="bottom-right"/>
+  <property name="initial-opacity" type="double" value="1.0"/>
 </channel>

--- a/files/system/usr/share/xfconf-profile/default.json
+++ b/files/system/usr/share/xfconf-profile/default.json
@@ -21,7 +21,8 @@
     },
     "xfce4-notifyd": {
       "/theme": "Chicago95",
-      "/notify-location": "bottom-right"
+      "/notify-location": "bottom-right",
+      "/initial-opacity": 1.0
     },
     "xfce4-terminal": {
       "/misc-toolbar-default": true


### PR DESCRIPTION
Trying to merge upstream in https://github.com/grassmunk/Chicago95/pull/423

## Before

<img width="1920" height="1080" alt="volume-notifyd-before" src="https://github.com/user-attachments/assets/e1911696-b486-4460-bd54-5de231fd60f7" />

## After

<img width="1920" height="1080" alt="volume-notifyd-after" src="https://github.com/user-attachments/assets/f964a3fa-6e38-4031-9a62-f1c1d2d98bf4" />

