### PR TITLE
ui: add 1px padding to menubar items

### DIFF
--- a/files/scripts/20-chicago95-menubar-padding.diff
+++ b/files/scripts/20-chicago95-menubar-padding.diff
@@ -1,0 +1,15 @@
+diff --git a/Theme/Chicago95/gtk-3.0/gtk-menu.css b/Theme/Chicago95/gtk-3.0/gtk-menu.css
+index ec5c90f..5b5ed6c 100644
+--- a/Theme/Chicago95/gtk-3.0/gtk-menu.css
++++ b/Theme/Chicago95/gtk-3.0/gtk-menu.css
+@@ -48,8 +48,8 @@ menubar,
+   color: @menu_text_color;
+   text-shadow: none;
+   -gtk-icon-shadow: none; }
+-  menubar menuitem {
+-    padding: 0px 6px;
++  menubar menuitem {
++    padding: 1px 6px;
+     min-height:20px; }
+ 
+ menu separator {

--- a/files/scripts/20-chicago95.sh
+++ b/files/scripts/20-chicago95.sh
@@ -5,6 +5,7 @@ set -xueo pipefail
 diff=$(realpath 20-chicago95.diff)
 xfwm4_diff=$(realpath 20-chicago95-xfwm4.diff)
 notifyd_diff=$(realpath 20-chicago95-notifyd.diff)
+menubar_diff=$(realpath 20-chicago95-menubar-padding.diff)
 
 # Fetch
 TMPDIR=$(mktemp -d)
@@ -24,6 +25,9 @@ patch -p1 <$xfwm4_diff
 
 # Fix volume notification icon rendering (force regular/color icons over symbolic)
 patch -p1 <$notifyd_diff
+
+# Fix menubar dropdown popup appearing too close to menu bar text
+patch -p1 <$menubar_diff
 
 # Themes
 cp -r Theme/Chicago95 /usr/share/themes


### PR DESCRIPTION
When clicking on a menu item, there is no padding between the item and the dropdown menu that appears, making the design feel cramped. This PR adds a 1px padding to menu items, which I believe strikes a good balance between no padding (current) and a more modern amount of padding (2px+).

## 0px (Current)
<img width="916" height="707" alt="before" src="https://github.com/user-attachments/assets/3a38d179-ce0d-4c09-9d96-6ddf3736ae83" />

## 1px (This PR)

<img width="915" height="705" alt="after-1px" src="https://github.com/user-attachments/assets/b16fe363-d408-4470-b3ac-2bb1f4cd4261" />

## 2px
<img width="921" height="706" alt="after-2px" src="https://github.com/user-attachments/assets/f4f478e2-b04b-4f5d-9925-76e2313a5257" />

