### PR TITLE
ui: add horizontal padding to desktop icon labels

### DIFF
--- a/files/scripts/20-chicago95-desktop-icon-label-padding.diff
+++ b/files/scripts/20-chicago95-desktop-icon-label-padding.diff
@@ -1,0 +1,16 @@
+diff --git a/Theme/Chicago95/gtk-3.0/apps/xfce.css b/Theme/Chicago95/gtk-3.0/apps/xfce.css
+index 6f13279..0659f9a 100644
+--- a/Theme/Chicago95/gtk-3.0/apps/xfce.css
++++ b/Theme/Chicago95/gtk-3.0/apps/xfce.css
+@@ -17,7 +17,10 @@ XfdesktopIconView.view {
+   background-size: calc(100% - 10px) calc(100% - 10px);
+   color: @selected_bg_color;
+   border-radius: 0px; 
+-  background-color: rgba(0, 0, 0, 0)}
++  background-color: rgba(0, 0, 0, 0);
++  -XfdesktopIconView-label-radius: 7;
++  -XfdesktopIconView-cell-spacing: 1;
++}
+   XfdesktopIconView.view:active {
+     background-image: -gtk-gradient(linear, left top, right bottom, from (@selected_bg_color));
+     text-shadow: none;

--- a/files/scripts/20-chicago95.sh
+++ b/files/scripts/20-chicago95.sh
@@ -6,6 +6,7 @@ diff=$(realpath 20-chicago95.diff)
 xfwm4_diff=$(realpath 20-chicago95-xfwm4.diff)
 notifyd_diff=$(realpath 20-chicago95-notifyd.diff)
 menubar_diff=$(realpath 20-chicago95-menubar-padding.diff)
+icon_label_padding_diff=$(realpath 20-chicago95-desktop-icon-label-padding.diff)
 
 # Fetch
 TMPDIR=$(mktemp -d)
@@ -28,6 +29,9 @@ patch -p1 <$notifyd_diff
 
 # Fix menubar dropdown popup appearing too close to menu bar text
 patch -p1 <$menubar_diff
+
+# Add padding to desktop icon labels
+patch -p1 <$icon_label_padding_diff
 
 # Themes
 cp -r Theme/Chicago95 /usr/share/themes


### PR DESCRIPTION
Labels should have some amount of horizontal padding.

## Before

<img width="676" height="711" alt="Screenshot_2026-06-22_10-43-41" src="https://github.com/user-attachments/assets/ae6ef450-772c-4827-b4fc-083acf211798" />


## After

<img width="599" height="695" alt="Screenshot_2026-06-22_11-08-21" src="https://github.com/user-attachments/assets/1a1693ca-75a9-4c39-814a-b83e1d1016ab" />
